### PR TITLE
Set up CI for Scala 3 migration

### DIFF
--- a/.github/workflows/ci-it.yml
+++ b/.github/workflows/ci-it.yml
@@ -5,7 +5,7 @@ env:
   GOOGLE_APPLICATION_CREDENTIALS: scripts/gha-data-integration-test.json
   GOOGLE_PROJECT_ID: data-integration-test
 
-on: push
+on: release
 
 jobs:
   it-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-on: [push, pull_request]
+on: release
 
 jobs:
   checks:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,7 @@ env:
   GOOGLE_APPLICATION_CREDENTIALS: scripts/gha-data-integration-test.json
   GOOGLE_PROJECT_ID: data-integration-test
 
-on:
-  push:
-    tags: ["*"]
+on: release
 
 jobs:
   publish-repl:

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -8,46 +8,46 @@ jobs:
       fail-fast: false
       matrix:
         task:
-          - scio-sql/compile
-          - scio-sql/test
-          - scio-parquet/compile
-          - scio-parquet/test
-          - scio-elasticsearch7/compile
-          - scio-elasticsearch7/test
-          - scio-repl/compile
-          - scio-repl/test
-          - scio-jmh/compile
-          - scio-jmh/test
-          - scio-jdbc/compile
-          - scio-jdbc/test
-          - scio-extra/compile
-          - scio-extra/test
+          # - scio-sql/compile
+          # - scio-sql/test
+          # - scio-parquet/compile
+          # - scio-parquet/test
+          # - scio-elasticsearch7/compile
+          # - scio-elasticsearch7/test
+          # - scio-repl/compile
+          # - scio-repl/test
+          # - scio-jmh/compile
+          # - scio-jmh/test
+          # - scio-jdbc/compile
+          # - scio-jdbc/test
+          # - scio-extra/compile
+          # - scio-extra/test
           - scio-core/compile
           - scio-core/test
-          - scio-examples/compile
-          - scio-examples/test
-          - scio-redis/compile
-          - scio-redis/test
-          - scio-schemas/compile
-          - scio-schemas/test
-          - scio-cassandra3/compile
-          - scio-cassandra3/test
-          - scio-tensorflow/compile
-          - scio-tensorflow/test
+          # - scio-examples/compile
+          # - scio-examples/test
+          # - scio-redis/compile
+          # - scio-redis/test
+          # - scio-schemas/compile
+          # - scio-schemas/test
+          # - scio-cassandra3/compile
+          # - scio-cassandra3/test
+          # - scio-tensorflow/compile
+          # - scio-tensorflow/test
           - scio-macros/compile
           - scio-macros/test
-          - scio-test/compile
-          - scio-test/test
-          - scio-avro/compile
-          - scio-avro/test
-          - scio-google-cloud-platform/compile
-          - scio-google-cloud-platform/test
-          - scio-elasticsearch6/compile
-          - scio-elasticsearch6/test
-          - scio-smb/compile
-          - scio-smb/test
-          - steps/compile
-          - steps/test
+          # - scio-test/compile
+          # - scio-test/test
+          # - scio-avro/compile
+          # - scio-avro/test
+          # - scio-google-cloud-platform/compile
+          # - scio-google-cloud-platform/test
+          # - scio-elasticsearch6/compile
+          # - scio-elasticsearch6/test
+          # - scio-smb/compile
+          # - scio-smb/test
+          # - steps/compile
+          # - steps/test
     steps:
       - uses: actions/checkout@v2.3.4
       - name: cache SBT

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -22,8 +22,8 @@ jobs:
           # - scio-jdbc/test
           # - scio-extra/compile
           # - scio-extra/test
-          - scio-core/compile
-          - scio-core/test
+          # - scio-core/compile
+          # - scio-core/test
           # - scio-examples/compile
           # - scio-examples/test
           # - scio-redis/compile

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -5,6 +5,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         task:
           - scio-sql/compile

--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -1,0 +1,57 @@
+name: Migration
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        task:
+          - scio-sql/compile
+          - scio-sql/test
+          - scio-parquet/compile
+          - scio-parquet/test
+          - scio-elasticsearch7/compile
+          - scio-elasticsearch7/test
+          - scio-repl/compile
+          - scio-repl/test
+          - scio-jmh/compile
+          - scio-jmh/test
+          - scio-jdbc/compile
+          - scio-jdbc/test
+          - scio-extra/compile
+          - scio-extra/test
+          - scio-core/compile
+          - scio-core/test
+          - scio-examples/compile
+          - scio-examples/test
+          - scio-redis/compile
+          - scio-redis/test
+          - scio-schemas/compile
+          - scio-schemas/test
+          - scio-cassandra3/compile
+          - scio-cassandra3/test
+          - scio-tensorflow/compile
+          - scio-tensorflow/test
+          - scio-macros/compile
+          - scio-macros/test
+          - scio-test/compile
+          - scio-test/test
+          - scio-avro/compile
+          - scio-avro/test
+          - scio-google-cloud-platform/compile
+          - scio-google-cloud-platform/test
+          - scio-elasticsearch6/compile
+          - scio-elasticsearch6/test
+          - scio-smb/compile
+          - scio-smb/test
+          - steps/compile
+          - steps/test
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: cache SBT
+        uses: coursier/cache-action@v5
+      - name: java 8 setup
+        uses: olafurpg/setup-scala@v10
+      - name: Compile
+        run: sbt "++3.0.0-RC1;${{ matrix.task }}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,9 +1,6 @@
 name: Release Drafter
 
-on:
-  push:
-    branches:
-      - master
+on: release
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: release
-on:
-    push:
-        branches: [master]
-        tags: ["*"]
+on: release
 jobs:
     publish:
         runs-on: ubuntu-latest

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ import de.heikoseeberger.sbtheader.CommentCreator
 
 ThisBuild / turbo := true
 
+val scala3Version = "3.0.0-RC1"
 val algebirdVersion = "0.13.7"
 val algebraVersion = "2.0.1"
 val annoy4sVersion = "0.9.0"
@@ -143,7 +144,7 @@ val commonSettings = Def
     headerLicense := Some(HeaderLicense.ALv2("2020", "Spotify AB")),
     headerMappings := headerMappings.value + (HeaderFileType.scala -> keepExistingHeader, HeaderFileType.java -> keepExistingHeader),
     scalaVersion := "2.13.3",
-    crossScalaVersions := Seq("2.12.12", scalaVersion.value, "3.0.0-M2"),
+    crossScalaVersions := Seq("2.12.12", scalaVersion.value, scala3Version),
     scalacOptions ++= Scalac.commonsOptions.value,
     Compile / doc / scalacOptions --= Seq("-release", "8"),
     Compile / doc / scalacOptions ++= Scalac.compileDocOptions.value,
@@ -574,7 +575,7 @@ lazy val `scio-macros`: Project = project
       else Nil
     },
     // Scala3 setting
-    crossScalaVersions += "3.0.0-M2"
+    crossScalaVersions += scala3Version
   )
 
 lazy val `scio-avro`: Project = project

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,7 @@ addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.4")
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.4")
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")
 
 libraryDependencies ++= Seq(
   "com.github.os72" % "protoc-jar" % "3.11.4",

--- a/scio-core/src/main/scala-3/com/spotify/scio/coders/macros/FallbackCoderMacros.scala
+++ b/scio-core/src/main/scala-3/com/spotify/scio/coders/macros/FallbackCoderMacros.scala
@@ -31,7 +31,7 @@ object FallbackCoderMacros {
     // val show = MacroSettings.showCoderFallback(c) == FeatureFlag.Enable
     val show = true
 
-    val fullTypeColored = Type.showAnsiColored[T]
+    val fullTypeColored = Type.show[T]
     val fullType = Type.show[T]
     val typeName: String = fullType.split('.').last // TODO: Type.showShort[T] ?
 

--- a/scio-core/src/main/scala/com/spotify/scio/coders/instances/ScalaCoders.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/coders/instances/ScalaCoders.scala
@@ -233,7 +233,7 @@ private class SortedSetCoder[T: Ordering](bc: BCoder[T]) extends SeqLikeCoder[So
     decode(inStream, SortedSet.newBuilder[T])
 }
 
-private class BitSetCoder extends AtomicCoder[BitSet] {
+private class BitSetCoderInternal extends AtomicCoder[BitSet] {
   private[this] val lc = VarIntCoder.of()
 
   def decode(in: InputStream): BitSet = {
@@ -451,7 +451,7 @@ trait ScalaCoders {
   implicit def noneCoder: Coder[None.type] =
     optionCoder[Nothing, Option](nothingCoder).asInstanceOf[Coder[None.type]]
 
-  implicit def bitSetCoder: Coder[BitSet] = Coder.beam(new BitSetCoder)
+  implicit def bitSetCoder: Coder[BitSet] = Coder.beam(new BitSetCoderInternal)
 
   implicit def seqCoder[T: Coder]: Coder[Seq[T]] =
     Coder.transform(Coder[T])(bc => Coder.beam(new SeqCoder[T](bc)))

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/SchemaMaterializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/SchemaMaterializer.scala
@@ -198,7 +198,7 @@ object SchemaMaterializer {
         (bschema, toRow, fromRow)
       case _ =>
         implicit val imp = schema
-        val (bschema, to, from) = materialize(implicitly[Schema[ScalarWrapper[T]]])
+        val (bschema, to, from) = materialize(ScalarWrapper.schemaScalarWrapper[T])
 
         def fromRow =
           new SerializableFunction[Row, T] {
@@ -219,6 +219,6 @@ object SchemaMaterializer {
     case s @ (_: Record[T] | _: RawRecord[T]) =>
       SchemaMaterializer.fieldType(s).getRowSchema
     case _ =>
-      SchemaMaterializer.fieldType(Schema[ScalarWrapper[T]]).getRowSchema
+      SchemaMaterializer.fieldType(Schema[ScalarWrapper[T]](ScalarWrapper.schemaScalarWrapper[T])).getRowSchema
   }
 }

--- a/scio-macros/src/main/scala-3/com/spotify/scio/DerivationUtils.scala
+++ b/scio-macros/src/main/scala-3/com/spotify/scio/DerivationUtils.scala
@@ -21,13 +21,13 @@ import scala.compiletime._
 import scala.deriving._
 
 object DerivationUtils {
-  inline given mirrorFields[Fields <: Tuple] as List[String] =
+  inline given mirrorFields[Fields <: Tuple]: List[String] =
     inline erasedValue[Fields] match {
       case _: (field *: fields) => constValue[field].toString :: mirrorFields[fields]
       case _ => Nil
     }
 
-  inline given summonAllF[F[_], T <: Tuple] as Widen[T] = {
+  inline given summonAllF[F[_], T <: Tuple]: Widen[T] = {
     val res =
       inline erasedValue[T] match {
         case _: EmptyTuple => EmptyTuple

--- a/scio-macros/src/main/scala-3/com/spotify/scio/IsJava.scala
+++ b/scio-macros/src/main/scala-3/com/spotify/scio/IsJava.scala
@@ -28,7 +28,7 @@ object IsJavaBean {
 
   private def checkGetterAndSetters(using q: Quotes)(sym: q.reflect.Symbol): Unit = {
     import q.reflect._
-    val methods: List[Symbol] = sym.classMethods
+    val methods: List[Symbol] = sym.declaredMethods
 
     val getters =
       methods.collect {
@@ -59,15 +59,18 @@ object IsJavaBean {
             report.throwError(mess)
           }
 
-      val resType = info.returnTpt.tpe
-      val paramType = setter.paramss.head.head.tpt.tpe
-
-      if (resType != paramType) {
-          val mess =
-            s"""JavaBean contained setter for field $name that had a mismatching type.
-                  |  found:    $paramType
-                  |  expected: $resType""".stripMargin
-          report.throwError(mess)
+      val resType: TypeRepr = info.returnTpt.tpe
+      setter.paramss.head match {
+        case TypeParamClause(params: List[TypeDef]) => report.throwError(s"JavaBean setter for field $name has type parameters")
+        case TermParamClause(head :: _) => 
+          val tpe = head.tpt.tpe
+          if (resType != tpe) {
+            val mess =
+              s"""JavaBean contained setter for field $name that had a mismatching type.
+                    |  found:    $tpe
+                    |  expected: $resType""".stripMargin
+            report.throwError(mess)
+          }
       }
     }
   }

--- a/scio-macros/src/main/scala-3/com/spotify/scio/IsJava.scala
+++ b/scio-macros/src/main/scala-3/com/spotify/scio/IsJava.scala
@@ -80,7 +80,7 @@ object IsJavaBean {
     '{new IsJavaBean[T]{}}
   }
 
-  inline given isJavaBean[T] as IsJavaBean[T] = {
+  inline given isJavaBean[T]: IsJavaBean[T] = {
     ${ isJavaBeanImpl[T] }
   }
 


### PR DESCRIPTION
Setting up a development environment for incrementally migrating Scio to Scala 3. A few notes:

- Other CI files have been set to run on `release` instead of on `push`. This is to ensure that we just run our migration CI, and not the full set of CI checks. This is crucial in order to be able to make incremental progresss 
- We have added a new CI workflow, `migration.yml`. Most projects are commented out in this; the idea is to uncomment them as we progress.
- We have updated the build to use the latest Scala 3 RC release, Scala 3.0.0-RC1.
- In order to get a single subproject to compile, we have updated the calls to Scala 3.0.0-RC1 TASTy reflection in `scio-macros` to migrate from 3.0.0-M1 to 3.0.0-RC1
- Future PRs can address issues on our repo. For instance, see #2 