### PR TITLE
sbt 1.5.0 and Scala 3.0.0-RC2 

### DIFF
--- a/.github/workflows/migration.yml
+++ b/.github/workflows/migration.yml
@@ -55,4 +55,4 @@ jobs:
       - name: java 8 setup
         uses: olafurpg/setup-scala@v10
       - name: Compile
-        run: sbt "++3.0.0-RC1;${{ matrix.task }}"
+        run: sbt "++3.0.0-RC2;${{ matrix.task }}"

--- a/apache.sbt
+++ b/apache.sbt
@@ -1,1 +1,1 @@
-resolvers in ThisBuild += "apache-snapshots" at "https://repository.apache.org/snapshots/"
+ThisBuild / resolvers in ThisBuild += "apache-snapshots" at "https://repository.apache.org/snapshots/"

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ import de.heikoseeberger.sbtheader.CommentCreator
 
 ThisBuild / turbo := true
 
-val scala3Version = "3.0.0-RC1"
+val scala3Version = "3.0.0-RC2"
 val algebirdVersion = "0.13.7"
 val algebraVersion = "2.2.1"
 val annoy4sVersion = "0.9.0"

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ ThisBuild / turbo := true
 
 val scala3Version = "3.0.0-RC2"
 val algebirdVersion = "0.13.7"
-val algebraVersion = "2.2.1"
+val algebraVersion = "2.2.2"
 val annoy4sVersion = "0.9.0"
 val annoyVersion = "0.2.6"
 val asmVersion = "4.13"
@@ -42,7 +42,7 @@ val bigtableClientVersion = "1.16.0"
 val breezeVersion = "1.1"
 val caffeineVersion = "2.9.0"
 val caseappVersion = "2.0.4"
-val catsVersion = "2.1.1"
+val catsVersion = "2.5.0"
 val chillVersion = "0.9.5"
 val circeVersion = "0.13.0"
 val commonsCompressVersion = "1.20"
@@ -96,14 +96,14 @@ val protobufVersion = "3.15.6"
 val scalacheckVersion = "1.15.3"
 val scalaMacrosVersion = "2.1.1"
 val scalatestplusVersion = "3.1.0.0-RC2"
-val scalatestVersion = "3.2.6"
+val scalatestVersion = "3.2.7"
 val shapelessVersion = "2.3.3"
 val slf4jVersion = "1.7.30"
 val sparkeyVersion = "3.2.1"
 val sparkVersion = "2.4.6"
 val tensorFlowVersion = "0.2.0"
 val zoltarVersion = "0.6.0-M2"
-val scalaCollectionCompatVersion = "2.4.2"
+val scalaCollectionCompatVersion = "2.4.3"
 
 ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value)
 val excludeLint = SettingKey[Set[Def.KeyedInitialize[_]]]("excludeLintKeys")
@@ -147,7 +147,7 @@ val commonSettings = Def
     scalacOptions ++= Scalac.commonsOptions.value,
     Compile / doc / scalacOptions := Scalac.docOptions.value,
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked"),
-    javacOptions in (Compile, doc) := Seq("-source", "1.8"),
+    Compile / doc / javacOptions := Seq("-source", "1.8"),
     // protobuf-lite is an older subset of protobuf-java and causes issues
     excludeDependencies += "com.google.protobuf" % "protobuf-lite",
     resolvers += Resolver.sonatypeRepo("public"),
@@ -235,7 +235,7 @@ lazy val itSettings = Def.settings(
   Defaults.itSettings,
   IntegrationTest / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
   // exclude all sources if we don't have GCP credentials
-  (excludeFilter in unmanagedSources) in IntegrationTest := {
+  IntegrationTest / unmanagedSources / excludeFilter := {
     if (BuildCredentials.exists) {
       HiddenFileFilter
     } else {
@@ -249,8 +249,8 @@ lazy val itSettings = Def.settings(
 )
 
 lazy val assemblySettings = Seq(
-  test in assembly := {},
-  assemblyMergeStrategy in assembly ~= { old =>
+  assembly / test := {},
+  assembly / assemblyMergeStrategy ~= { old =>
     {
       case s if s.endsWith(".properties")            => MergeStrategy.filterDistinctLines
       case s if s.endsWith("public-suffix-list.txt") => MergeStrategy.filterDistinctLines
@@ -275,7 +275,7 @@ lazy val assemblySettings = Seq(
 
 lazy val macroSettings = Def.settings(
   libraryDependencies ++= {
-    if (!isDotty.value)
+    if (!scalaVersion.value.startsWith("3"))
       Seq("org.scala-lang" % "scala-reflect" % scalaVersion.value)
     else Nil
   },
@@ -344,11 +344,11 @@ def beamRunnerSettings: Seq[Setting[_]] = Seq(
 )
 
 lazy val protobufSettings = Def.settings(
-  version in ProtobufConfig := protobufVersion,
-  protobufRunProtoc in ProtobufConfig := (args =>
+  ProtobufConfig / version := protobufVersion,
+  ProtobufConfig / protobufRunProtoc := (args =>
     com.github.os72.protocjar.Protoc.runProtoc("-v3.11.4" +: args.toArray)
   ),
-  libraryDependencies += "com.google.protobuf" % "protobuf-java" % (version in ProtobufConfig).value % ProtobufConfig.name
+  libraryDependencies += "com.google.protobuf" % "protobuf-java" % (ProtobufConfig / version).value % ProtobufConfig.name
 )
 
 def splitTests(tests: Seq[TestDefinition], filter: Seq[String], forkOptions: ForkOptions) = {
@@ -392,16 +392,14 @@ lazy val `scio-core`: Project = project
   .settings(itSettings)
   .settings(
     description := "Scio - A Scala API for Apache Beam and Google Cloud Dataflow",
-    resources in Compile ++= Seq(
-      (baseDirectory in ThisBuild).value / "build.sbt",
-      (baseDirectory in ThisBuild).value / "version.sbt"
+    Compile / resources ++= Seq(
+      (ThisBuild / baseDirectory).value / "build.sbt",
+      (ThisBuild / baseDirectory).value / "version.sbt"
     ),
+    // Java dependencies
     libraryDependencies ++= Seq(
       "com.esotericsoftware" % "kryo-shaded" % kryoVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
-      "com.github.alexarchambault" %% "case-app" % caseappVersion,
-      "com.github.alexarchambault" %% "case-app-annotations" % caseappVersion,
       "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion % "provided",
       "com.google.api-client" % "google-api-client" % googleClientsVersion,
       "com.google.apis" % "google-api-services-dataflow" % googleApiServicesDataflow,
@@ -412,9 +410,6 @@ lazy val `scio-core`: Project = project
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
       "com.twitter" % "chill-java" % chillVersion,
       "com.twitter" % "chill-protobuf" % chillVersion,
-      "com.twitter" %% "algebird-core" % algebirdVersion,
-      "com.twitter" %% "chill" % chillVersion,
-      "com.twitter" %% "chill-algebird" % chillVersion,
       "commons-io" % "commons-io" % commonsIoVersion,
       "io.grpc" % "grpc-auth" % grpcVersion,
       "io.grpc" % "grpc-core" % grpcVersion,
@@ -423,7 +418,6 @@ lazy val `scio-core`: Project = project
       "io.grpc" % "grpc-stub" % grpcVersion,
       "io.netty" % "netty-handler" % nettyVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
-      ("me.lyh" %% "protobuf-generic" % protobufGenericVersion),
       "org.apache.avro" % "avro" % avroVersion,
       "org.apache.beam" % "beam-runners-core-construction-java" % beamVersion,
       "org.apache.beam" % "beam-runners-google-cloud-dataflow-java" % beamVersion % Provided,
@@ -441,23 +435,43 @@ lazy val `scio-core`: Project = project
       "org.apache.beam" % "beam-vendor-guava-26_0-jre" % beamVendorVersion,
       "org.apache.commons" % "commons-compress" % commonsCompressVersion,
       "org.apache.commons" % "commons-math3" % commonsMath3Version,
-      "org.scalatest" %% "scalatest" % scalatestVersion % Test,
-      "org.slf4j" % "slf4j-api" % slf4jVersion,
-      "org.typelevel" %% "algebra" % algebraVersion,
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion
-    ).map(_.withDottyCompat(scalaVersion.value)),
+      "org.slf4j" % "slf4j-api" % slf4jVersion
+    ),
+    // Scala dependencies not ported to Scala 3 yet
+    libraryDependencies ++= Seq(
+     "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
+     "com.github.alexarchambault" %% "case-app" % caseappVersion,
+     "com.github.alexarchambault" %% "case-app-annotations" % caseappVersion,
+     "com.twitter" %% "algebird-core" % algebirdVersion,
+     "com.twitter" %% "chill" % chillVersion,
+     "com.twitter" %% "chill-algebird" % chillVersion,
+     "me.lyh" %% "protobuf-generic" % protobufGenericVersion,
+     "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+     "org.typelevel" %% "algebra" % algebraVersion
+    ).map(_.cross(CrossVersion.for3Use2_13)),
+    // Scala dependencies available for 2.12, 2.13 and 3
+    libraryDependencies ++= Seq(
+     "org.scalatest" %% "scalatest" % scalatestVersion % Test,
+    ),
     buildInfoKeys := Seq[BuildInfoKey](scalaVersion, version, "beamVersion" -> beamVersion),
     buildInfoPackage := "com.spotify.scio",
     libraryDependencies ++= {
-      if (!isDotty.value)
+      if (!scalaVersion.value.startsWith("3"))
         Seq(
           "com.chuusai" %% "shapeless" % shapelessVersion,
           "com.propensive" %% "magnolia" % magnoliaVersion
         )
       else Nil
     },
+    libraryDependencies ++= {
+      if (scalaVersion.value.startsWith("2.12"))
+        Seq(
+          "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+        )
+      else Nil
+    },
     scalacOptions ++= {
-      if (isDotty.value) Seq("-source:3.0-migration") else Nil
+      if (scalaVersion.value.startsWith("3")) Seq("-source:3.0-migration") else Nil
     },
     compileOrder := CompileOrder.JavaThenScala,
   )
@@ -478,14 +492,14 @@ lazy val `scio-sql`: Project = project
   .settings(
     description := "Scio - SQL extension",
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+      //"org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-extensions-sql" % beamVersion,
       "org.apache.commons" % "commons-lang3" % commonsLang3Version,
       "org.apache.beam" % "beam-vendor-calcite-1_20_0" % beamVendorVersion
-    ).map(_.withDottyCompat(scalaVersion.value)),
+    ),
     scalacOptions ++= {
-      if (isDotty.value) Seq("-source:3.0-migration") else Nil
+      if (scalaVersion.value.startsWith("3")) Seq("-source:3.0-migration") else Nil
     },
     Test / compileOrder := CompileOrder.JavaThenScala
   )
@@ -505,38 +519,45 @@ lazy val `scio-test`: Project = project
   .settings(macroSettings)
   .settings(
     description := "Scio helpers for ScalaTest",
+    // Java dependencies
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.apache.beam" % "beam-runners-direct-java" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-io-google-cloud-platform" % beamVersion,
       "org.apache.beam" % "beam-runners-google-cloud-dataflow-java" % beamVersion % "test,it",
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion % "test",
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion % "test" classifier "tests",
-      "org.scalatest" %% "scalatest" % scalatestVersion,
-      "org.scalatestplus" %% "scalatestplus-scalacheck" % scalatestplusVersion % "test,it",
-      "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test,it",
-      "com.spotify" %% "magnolify-datastore" % magnolifyVersion % "it",
-      "com.spotify" %% "magnolify-guava" % magnolifyVersion,
       // DataFlow testing requires junit and hamcrest
       "org.hamcrest" % "hamcrest-core" % hamcrestVersion,
       "org.hamcrest" % "hamcrest-library" % hamcrestVersion,
-      // Our BloomFilters are Algebird Monoids and hence uses tests from Algebird Test
-      "com.twitter" %% "algebird-test" % algebirdVersion % "test",
       "com.spotify" % "annoy" % annoyVersion % "test",
       "com.spotify.sparkey" % "sparkey" % sparkeyVersion % "test",
       "com.novocode" % "junit-interface" % junitInterfaceVersion,
       "junit" % "junit" % junitVersion % "test",
-      "com.lihaoyi" %% "pprint" % "0.6.3",
-      "com.chuusai" %% "shapeless" % shapelessVersion,
       "com.google.api.grpc" % "proto-google-cloud-bigtable-v2" % generatedGrpcBetaVersion,
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
-      "com.twitter" %% "chill" % chillVersion,
       "commons-io" % "commons-io" % commonsIoVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "org.hamcrest" % "hamcrest" % hamcrestVersion,
+    ),
+    // Scala dependencies available for 2.12, 2.13 and 3
+    libraryDependencies ++= Seq(
+      //"org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+      "org.scalatest" %% "scalatest" % scalatestVersion,
+      "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test,it",
+    ),
+    // Scala dependencies not ported to Scala 3 yet
+    libraryDependencies ++= Seq(
+      "org.scalatestplus" %% "scalatestplus-scalacheck" % scalatestplusVersion % "test,it",
+      "com.spotify" %% "magnolify-datastore" % magnolifyVersion % "it",
+      "com.spotify" %% "magnolify-guava" % magnolifyVersion,
+      // Our BloomFilters are Algebird Monoids and hence uses tests from Algebird Test
+      "com.twitter" %% "algebird-test" % algebirdVersion % "test",
+      "com.lihaoyi" %% "pprint" % "0.6.3",
+      "com.chuusai" %% "shapeless" % shapelessVersion,
+      "com.twitter" %% "chill" % chillVersion,
       "org.scalactic" %% "scalactic" % "3.2.6",
       "com.propensive" %% "magnolia" % magnoliaVersion
-    ).map(_.withDottyCompat(scalaVersion.value)),
+    ).map(_.cross(CrossVersion.for3Use2_13)),
     Test / compileOrder := CompileOrder.JavaThenScala,
     Test / testGrouping := splitTests(
       (Test / definedTests).value,
@@ -544,7 +565,7 @@ lazy val `scio-test`: Project = project
       (Test / forkOptions).value
     ),
     scalacOptions ++= {
-      if (isDotty.value) Seq("-source:3.0-migration") else Nil
+      if (scalaVersion.value.startsWith("3")) Seq("-source:3.0-migration") else Nil
     },
   )
   .configs(IntegrationTest)
@@ -561,13 +582,15 @@ lazy val `scio-macros`: Project = project
   .settings(macroSettings)
   .settings(
     description := "Scio macros",
+    // Java dependencies
     libraryDependencies ++= Seq(
       "com.esotericsoftware" % "kryo-shaded" % kryoVersion,
       "org.apache.beam" % "beam-sdks-java-extensions-sql" % beamVersion,
       "org.apache.avro" % "avro" % avroVersion
     ),
+    // Scala 2 dependencies
     libraryDependencies ++= {
-      if (!isDotty.value)
+      if (!scalaVersion.value.startsWith("3"))
         Seq(
           "com.chuusai" %% "shapeless" % shapelessVersion,
           "com.propensive" %% "magnolia" % magnoliaVersion
@@ -586,25 +609,29 @@ lazy val `scio-avro`: Project = project
   .settings(itSettings)
   .settings(
     description := "Scio add-on for working with Avro",
+    // Java dependencies
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
-      "me.lyh" %% "protobuf-generic" % protobufGenericVersion,
       "org.apache.beam" % "beam-vendor-guava-26_0-jre" % beamVendorVersion,
       "org.apache.beam" % "beam-sdks-java-io-google-cloud-platform" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
-      "com.twitter" %% "chill" % chillVersion,
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
       "org.apache.avro" % "avro" % avroVersion exclude ("com.thoughtworks.paranamer", "paranamer"),
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "slf4j-simple" % slf4jVersion % "test,it",
-      "org.scalatest" %% "scalatest" % scalatestVersion % "test,it",
+    ),
+    // Scala dependencies not ported to Scala 3 yet
+    libraryDependencies ++= Seq(
+      //"org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+      "me.lyh" %% "protobuf-generic" % protobufGenericVersion,
+     "com.twitter" %% "chill" % chillVersion,
+     "org.scalatest" %% "scalatest" % scalatestVersion % "test,it",
       "org.scalatestplus" %% "scalatestplus-scalacheck" % scalatestplusVersion % "test,it",
       "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test,it",
       "com.spotify" %% "magnolify-cats" % magnolifyVersion % "test",
       "com.spotify" %% "magnolify-scalacheck" % magnolifyVersion % "test"
-    ).map(_.withDottyCompat(scalaVersion.value)),
+    ).map(_.cross(CrossVersion.for3Use2_13)),
     scalacOptions ++= {
-      if (isDotty.value) Seq("-source:3.0-migration") else Nil
+      if (scalaVersion.value.startsWith("3")) Seq("-source:3.0-migration") else Nil
     },
   )
   .dependsOn(
@@ -621,6 +648,7 @@ lazy val `scio-google-cloud-platform`: Project = project
   .settings(beamRunnerSettings)
   .settings(
     description := "Scio add-on for Google Cloud Platform",
+    // Java dependecies
     libraryDependencies ++= Seq(
       "com.google.cloud" % "google-cloud-spanner" % googleCloudSpannerVersion excludeAll (
         ExclusionRule(organization = "io.grpc")
@@ -628,7 +656,6 @@ lazy val `scio-google-cloud-platform`: Project = project
       "com.google.cloud.bigtable" % "bigtable-client-core" % bigtableClientVersion excludeAll (
         ExclusionRule(organization = "io.grpc")
       ),
-      "com.chuusai" %% "shapeless" % shapelessVersion,
       "com.google.api-client" % "google-api-client" % googleClientsVersion,
       "com.google.api.grpc" % "proto-google-cloud-bigquerystorage-v1beta1" % "0.98.0",
       "com.google.api.grpc" % "proto-google-cloud-bigtable-admin-v2" % generatedGrpcBetaVersion,
@@ -646,9 +673,6 @@ lazy val `scio-google-cloud-platform`: Project = project
       "com.google.http-client" % "google-http-client-jackson2" % googleHttpClientsVersion,
       "com.google.http-client" % "google-http-client" % googleHttpClientsVersion,
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
-      "com.spotify" %% "magnolify-cats" % magnolifyVersion % "test",
-      "com.spotify" %% "magnolify-scalacheck" % magnolifyVersion % "test",
-      "com.twitter" %% "chill" % chillVersion,
       "commons-io" % "commons-io" % commonsIoVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
       "junit" % "junit" % junitVersion % "test",
@@ -659,12 +683,19 @@ lazy val `scio-google-cloud-platform`: Project = project
       "org.apache.beam" % "beam-vendor-guava-26_0-jre" % beamVendorVersion,
       "org.hamcrest" % "hamcrest-core" % hamcrestVersion % "test,it",
       "org.hamcrest" % "hamcrest-library" % hamcrestVersion % "test",
+      "org.slf4j" % "slf4j-api" % slf4jVersion,
+      "org.slf4j" % "slf4j-simple" % slf4jVersion % "test,it"
+    ),
+    // Scala dependencies not ported to Scala 3 yet
+    libraryDependencies ++= Seq(
+      "com.chuusai" %% "shapeless" % shapelessVersion,
+      "com.spotify" %% "magnolify-cats" % magnolifyVersion % "test",
+      "com.spotify" %% "magnolify-scalacheck" % magnolifyVersion % "test",
+      "com.twitter" %% "chill" % chillVersion,
       "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test,it",
       "org.scalatest" %% "scalatest" % scalatestVersion % "test,it",
       "org.scalatestplus" %% "scalatestplus-scalacheck" % scalatestplusVersion % "test,it",
-      "org.slf4j" % "slf4j-api" % slf4jVersion,
-      "org.slf4j" % "slf4j-simple" % slf4jVersion % "test,it"
-    ).map(_.withDottyCompat(scalaVersion.value)),
+     ).map(_.cross(CrossVersion.for3Use2_13)),
     compileOrder := CompileOrder.JavaThenScala, // required for Scala 3
   )
   .dependsOn(
@@ -682,23 +713,27 @@ lazy val `scio-cassandra3`: Project = project
   .settings(itSettings)
   .settings(
     description := "Scio add-on for Apache Cassandra 3.x",
+    // Java dependencies
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
       "com.google.guava" % "guava" % guavaVersion,
-      "com.twitter" %% "chill" % chillVersion,
       "com.datastax.cassandra" % "cassandra-driver-core" % "3.11.0",
       ("org.apache.cassandra" % "cassandra-all" % "3.11.10")
         .exclude("ch.qos.logback", "logback-classic")
         .exclude("org.slf4j", "log4j-over-slf4j"),
       "org.apache.hadoop" % "hadoop-common" % hadoopVersion,
       "org.apache.hadoop" % "hadoop-mapreduce-client-core" % hadoopVersion,
-      "org.scalatest" %% "scalatest" % scalatestVersion % Test,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion % Test,
       "com.esotericsoftware" % "kryo-shaded" % kryoVersion,
       "com.google.guava" % "guava" % guavaVersion,
       "com.twitter" % "chill-java" % chillVersion
-    ).map(_.withDottyCompat(scalaVersion.value))
+    ),
+    // Scala dependencies available for 2.12, 2.13 and 3
+    libraryDependencies ++= Seq(
+      //"org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+      ("com.twitter" %% "chill" % chillVersion).cross(CrossVersion.for3Use2_13),
+      "org.scalatest" %% "scalatest" % scalatestVersion % Test,
+   )
   )
   .dependsOn(
     `scio-core`,
@@ -712,8 +747,8 @@ lazy val `scio-elasticsearch6`: Project = project
   .settings(publishSettings)
   .settings(
     description := "Scio add-on for writing to Elasticsearch",
+    // Java dependencies
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.apache.beam" % "beam-vendor-guava-26_0-jre" % beamVendorVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
@@ -721,7 +756,8 @@ lazy val `scio-elasticsearch6`: Project = project
       "org.elasticsearch" % "elasticsearch" % elasticsearch6Version,
       "org.elasticsearch" % "elasticsearch-x-content" % elasticsearch6Version,
       "org.elasticsearch.client" % "transport" % elasticsearch6Version
-    ).map(_.withDottyCompat(scalaVersion.value)),
+    ),
+    //libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
     compileOrder := CompileOrder.JavaThenScala, // required for Scala 3
   )
   .dependsOn(
@@ -735,8 +771,8 @@ lazy val `scio-elasticsearch7`: Project = project
   .settings(publishSettings)
   .settings(
     description := "Scio add-on for writing to Elasticsearch",
+    // Java dependencies
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.apache.beam" % "beam-vendor-guava-26_0-jre" % beamVendorVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
@@ -747,7 +783,8 @@ lazy val `scio-elasticsearch7`: Project = project
       "org.elasticsearch.client" % "elasticsearch-rest-high-level-client" % elasticsearch7Version,
       "org.apache.httpcomponents" % "httpcore" % httpCoreVersion,
       "org.elasticsearch" % "elasticsearch" % elasticsearch7Version
-    ).map(_.withDottyCompat(scalaVersion.value)),
+    ),
+    //libraryDependencies += "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
     compileOrder := CompileOrder.JavaThenScala, // required for Scala 3
   )
   .dependsOn(
@@ -763,8 +800,8 @@ lazy val `scio-extra`: Project = project
   .settings(macroSettings)
   .settings(
     description := "Scio extra utilities",
+    // Java dependencies
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-io-google-cloud-platform" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-extensions-sorter" % beamVersion,
@@ -774,24 +811,28 @@ lazy val `scio-extra`: Project = project
       "org.apache.avro" % "avro" % avroVersion,
       "com.spotify" % "annoy" % annoyVersion,
       "com.spotify.sparkey" % "sparkey" % sparkeyVersion,
-      "com.twitter" %% "algebird-core" % algebirdVersion,
       "info.debatty" % "java-lsh" % javaLshVersion,
-      "net.pishen" %% "annoy4s" % annoy4sVersion,
-      "org.scalanlp" %% "breeze" % breezeVersion,
       "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion % "test",
-      "com.nrinaudo" %% "kantan.csv" % kantanCsvVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
-      "org.scalatest" %% "scalatest" % scalatestVersion % "test",
-      "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test",
-      "com.chuusai" %% "shapeless" % shapelessVersion,
       "joda-time" % "joda-time" % jodaTimeVersion,
       "net.java.dev.jna" % "jna" % jnaVersion,
       "org.apache.beam" % "beam-vendor-guava-26_0-jre" % beamVendorVersion,
+    ),
+    // Scala dependencies not ported to Scala 3 yet
+    libraryDependencies ++= Seq(
+      //"org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+      "com.twitter" %% "algebird-core" % algebirdVersion,
+      "net.pishen" %% "annoy4s" % annoy4sVersion,
+      "org.scalanlp" %% "breeze" % breezeVersion,
+      "com.nrinaudo" %% "kantan.csv" % kantanCsvVersion,
+      "org.scalatest" %% "scalatest" % scalatestVersion % "test",
+      "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test",
+      "com.chuusai" %% "shapeless" % shapelessVersion,
       "org.typelevel" %% "algebra" % algebraVersion,
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion
-    ),
+    ).map(_.cross(CrossVersion.for3Use2_13)),
     Compile / sourceDirectories := (Compile / sourceDirectories).value
       .filterNot(_.getPath.endsWith("/src_managed/main")),
     Compile / managedSourceDirectories := (Compile / managedSourceDirectories).value
@@ -814,6 +855,7 @@ lazy val `scio-jdbc`: Project = project
   .settings(publishSettings)
   .settings(
     description := "Scio add-on for JDBC",
+    // Java dependencies
     libraryDependencies ++= Seq(
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-io-jdbc" % beamVersion
@@ -833,30 +875,23 @@ lazy val `scio-parquet`: Project = project
   .settings(
     // change annotation processor output directory so IntelliJ can pick them up
     ensureSourceManaged := IO.createDirectory(sourceManaged.value / "main"),
-    (compile in Compile) := Def.task {
+    (Compile / compile) := Def.task {
       val _ = ensureSourceManaged.value
-      (compile in Compile).value
+      (Compile / compile).value
     }.value,
     javacOptions ++= Seq("-s", (sourceManaged.value / "main").toString),
     description := "Scio add-on for Parquet",
+    // Java dependencies
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
-      "me.lyh" %% "parquet-avro" % parquetExtraVersion excludeAll (
-        // parquet-avro depends on avro 1.10.x
-        ExclusionRule("org.apache.avro", "avro"),
-        ExclusionRule("org.apache.avro", "avro-compiler")
-      ),
       "org.apache.avro" % "avro" % avroVersion,
       "org.apache.avro" % "avro-compiler" % avroVersion,
       "me.lyh" % "parquet-tensorflow" % parquetExtraVersion,
       "com.google.cloud.bigdataoss" % "gcs-connector" % s"hadoop2-$bigdataossVersion",
-      "com.spotify" %% "magnolify-parquet" % magnolifyVersion,
       "org.apache.beam" % "beam-sdks-java-io-hadoop-format" % beamVersion,
       "org.apache.hadoop" % "hadoop-client" % hadoopVersion,
       "org.apache.parquet" % "parquet-avro" % parquetVersion exclude (
         "org.apache.avro", "avro"
       ),
-      "com.twitter" %% "chill" % chillVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-io-hadoop-common" % beamVersion,
       "org.apache.hadoop" % "hadoop-common" % hadoopVersion,
@@ -865,7 +900,18 @@ lazy val `scio-parquet`: Project = project
       "org.apache.parquet" % "parquet-common" % parquetVersion,
       "org.apache.parquet" % "parquet-hadoop" % parquetVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion
-    ).map(_.withDottyCompat(scalaVersion.value)),
+    ),
+    // Scala dependencies not ported to Scala 3 yet
+    libraryDependencies ++= Seq(
+      //"org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+      "me.lyh" %% "parquet-avro" % parquetExtraVersion excludeAll (
+        // parquet-avro depends on avro 1.10.x
+        ExclusionRule("org.apache.avro", "avro"),
+        ExclusionRule("org.apache.avro", "avro-compiler")
+      ),
+     "com.spotify" %% "magnolify-parquet" % magnolifyVersion,
+     "com.twitter" %% "chill" % chillVersion,
+    ).map(_.cross(CrossVersion.for3Use2_13)),
     compileOrder := CompileOrder.JavaThenScala
   )
   .dependsOn(
@@ -887,24 +933,28 @@ lazy val `scio-tensorflow`: Project = project
       .filterNot(_.getPath.endsWith("/src_managed/main")),
     Compile / managedSourceDirectories := (Compile / managedSourceDirectories).value
       .filterNot(_.getPath.endsWith("/src_managed/main")),
+    // Java dependencies
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "org.tensorflow" % "tensorflow-core-platform" % tensorFlowVersion,
       "org.apache.commons" % "commons-compress" % commonsCompressVersion,
-      "com.spotify" %% "featran-core" % featranVersion,
-      "com.spotify" %% "featran-scio" % featranVersion,
-      "com.spotify" %% "featran-tensorflow" % featranVersion,
       "com.spotify" % "zoltar-api" % zoltarVersion,
       "com.spotify" % "zoltar-tensorflow" % zoltarVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
-      "com.spotify" %% "magnolify-tensorflow" % magnolifyVersion % Test,
       "com.spotify" % "zoltar-core" % zoltarVersion,
       "org.apache.beam" % "beam-vendor-guava-26_0-jre" % beamVendorVersion
-    ).map(_.withDottyCompat(scalaVersion.value)),
+    ),
+    // Scala dependencies not ported to Scala 3 yet
+    libraryDependencies ++= Seq(
+      //"org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+      "com.spotify" %% "featran-core" % featranVersion,
+      "com.spotify" %% "featran-scio" % featranVersion,
+      "com.spotify" %% "featran-tensorflow" % featranVersion,
+      "com.spotify" %% "magnolify-tensorflow" % magnolifyVersion % Test,
+    ).map(_.cross(CrossVersion.for3Use2_13)),
     compileOrder := CompileOrder.JavaThenScala,
     scalacOptions ++= {
-      if (isDotty.value) Seq("-source:3.0-migration") else Nil // Easily fixable
+      if (scalaVersion.value.startsWith("3")) Seq("-source:3.0-migration") else Nil // Easily fixable
     },
   )
   .dependsOn(
@@ -921,15 +971,13 @@ lazy val `scio-schemas`: Project = project
   .settings(
     description := "Avro/Proto schemas for testing",
     publish / skip := true,
-    libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
-      "org.apache.avro" % "avro" % avroVersion
-    ).map(_.withDottyCompat(scalaVersion.value)),
+    //libraryDependencies +="org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion, 
+    libraryDependencies += "org.apache.avro" % "avro" % avroVersion,
     Compile / sourceDirectories := (Compile / sourceDirectories).value
       .filterNot(_.getPath.endsWith("/src_managed/main")),
     Compile / managedSourceDirectories := (Compile / managedSourceDirectories).value
       .filterNot(_.getPath.endsWith("/src_managed/main")),
-    sources in doc in Compile := List(), // suppress warnings
+    Compile / doc / sources := List(), // suppress warnings
     compileOrder := CompileOrder.JavaThenScala
   )
   .enablePlugins(ProtobufPlugin)
@@ -942,8 +990,8 @@ lazy val `scio-examples`: Project = project
   .settings(macroSettings)
   .settings(
     publish / skip := true,
+    // Java dependencies
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-io-google-cloud-platform" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-extensions-google-cloud-platform-core" % beamVersion,
@@ -954,19 +1002,11 @@ lazy val `scio-examples`: Project = project
       "com.google.api.grpc" % "proto-google-cloud-bigtable-v2" % generatedGrpcBetaVersion,
       "com.google.cloud.sql" % "mysql-socket-factory" % "1.2.1",
       "com.google.apis" % "google-api-services-bigquery" % googleApiServicesBigQuery,
-      "com.spotify" %% "magnolify-avro" % magnolifyVersion,
-      "com.spotify" %% "magnolify-datastore" % magnolifyVersion,
-      "com.spotify" %% "magnolify-tensorflow" % magnolifyVersion,
-      "com.spotify" %% "magnolify-bigtable" % magnolifyVersion,
       "mysql" % "mysql-connector-java" % "8.0.23",
       "joda-time" % "joda-time" % jodaTimeVersion,
       "com.github.alexarchambault" %% "case-app" % caseappVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "slf4j-simple" % slf4jVersion,
-      "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test",
-      "com.chuusai" %% "shapeless" % shapelessVersion,
-      "com.github.alexarchambault" %% "case-app-annotations" % caseappVersion,
-      "com.github.alexarchambault" %% "case-app-util" % caseappVersion,
       "com.google.api-client" % "google-api-client" % googleClientsVersion,
       "com.google.apis" % "google-api-services-pubsub" % s"v1-rev20200713-$googleClientsVersion",
       "com.google.auth" % "google-auth-library-credentials" % googleAuthVersion,
@@ -975,23 +1015,35 @@ lazy val `scio-examples`: Project = project
       "com.google.guava" % "guava" % guavaVersion,
       "com.google.oauth-client" % "google-oauth-client" % googleOauthClientVersion,
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
-      "com.spotify" %% "magnolify-shared" % magnolifyVersion,
-      "com.twitter" %% "algebird-core" % algebirdVersion,
       "org.apache.beam" % "beam-sdks-java-extensions-sql" % beamVersion,
       "org.apache.httpcomponents" % "httpcore" % httpCoreVersion,
-      "org.elasticsearch" % "elasticsearch" % elasticsearch7Version,
-      "com.propensive" %% "magnolia" % magnoliaVersion
+      "org.elasticsearch" % "elasticsearch" % elasticsearch7Version
     ),
+    // Scala dependencies not ported to Scala 3 yet
+    libraryDependencies ++= Seq(
+      //"org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+      "com.spotify" %% "magnolify-avro" % magnolifyVersion,
+      "com.spotify" %% "magnolify-datastore" % magnolifyVersion,
+      "com.spotify" %% "magnolify-tensorflow" % magnolifyVersion,
+      "com.spotify" %% "magnolify-bigtable" % magnolifyVersion,
+      "org.scalacheck" %% "scalacheck" % scalacheckVersion % "test",
+      "com.chuusai" %% "shapeless" % shapelessVersion,
+      "com.github.alexarchambault" %% "case-app-annotations" % caseappVersion,
+      "com.github.alexarchambault" %% "case-app-util" % caseappVersion,
+      "com.spotify" %% "magnolify-shared" % magnolifyVersion,
+      "com.twitter" %% "algebird-core" % algebirdVersion,
+      "com.propensive" %% "magnolia" % magnoliaVersion
+    ).map(_.cross(CrossVersion.for3Use2_13)),
     // exclude problematic sources if we don't have GCP credentials
-    excludeFilter in unmanagedSources := {
+    unmanagedSources / excludeFilter := {
       if (BuildCredentials.exists) {
         HiddenFileFilter
       } else {
         HiddenFileFilter || "TypedBigQueryTornadoes*.scala" || "TypedStorageBigQueryTornadoes*.scala"
       }
     },
-    fork in run := true,
-    sources in doc in Compile := List(),
+    run / fork := true,
+    Compile / doc / sources := List(),
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
     Test / testGrouping := splitTests(
       (Test / definedTests).value,
@@ -1021,8 +1073,9 @@ lazy val `scio-repl`: Project = project
   .settings(macroSettings)
   .settings(
     scalacOptions := Scalac.replOptions.value,
+    // Java dependencies
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+      //"org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.apache.beam" % "beam-runners-direct-java" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-io-google-cloud-platform" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-extensions-google-cloud-platform-core" % beamVersion,
@@ -1037,9 +1090,9 @@ lazy val `scio-repl`: Project = project
       "org.apache.commons" % "commons-text" % commonsTextVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "org.slf4j" % "slf4j-simple" % slf4jVersion,
-      "org.scala-lang" % "scala-compiler" % scalaVersion.value,
-      "com.nrinaudo" %% "kantan.csv" % kantanCsvVersion
+      "org.scala-lang" % "scala-compiler" % scalaVersion.value
     ),
+    libraryDependencies += ("com.nrinaudo" %% "kantan.csv" % kantanCsvVersion).cross(CrossVersion.for3Use2_13),
     libraryDependencies ++= {
       VersionNumber(scalaVersion.value) match {
         case v if v.matchesSemVer(SemanticSelector("2.12.x")) =>
@@ -1062,16 +1115,17 @@ lazy val `scio-jmh`: Project = project
   .settings(macroSettings)
   .settings(
     description := "Scio JMH Microbenchmarks",
-    sourceDirectory in Jmh := (sourceDirectory in Test).value,
-    classDirectory in Jmh := (classDirectory in Test).value,
-    dependencyClasspath in Jmh := (dependencyClasspath in Test).value,
+    Jmh / sourceDirectory := (Test / sourceDirectory).value,
+    Jmh / classDirectory := (Test / classDirectory).value,
+    Jmh / dependencyClasspath := (Test / dependencyClasspath).value,
+    // Java dependencies
     libraryDependencies ++= directRunnerDependencies ++ Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+      //"org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "junit" % "junit" % junitVersion % "test",
       "org.hamcrest" % "hamcrest-core" % hamcrestVersion % "test",
       "org.hamcrest" % "hamcrest-library" % hamcrestVersion % "test",
       "org.slf4j" % "slf4j-nop" % slf4jVersion
-    ).map(_.withDottyCompat(scalaVersion.value)),
+    ),
     publish / skip := true
   )
   .dependsOn(
@@ -1088,8 +1142,8 @@ lazy val `scio-smb`: Project = project
   .settings(beamRunnerSettings)
   .settings(
     description := "Sort Merge Bucket source/sink implementations for Apache Beam",
+    // Java dependencies
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "org.apache.avro" % "avro" % avroVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion % "it,test" classifier "tests",
@@ -1100,9 +1154,6 @@ lazy val `scio-smb`: Project = project
         "org.apache.avro", "avro"
       ),
       "org.apache.parquet" % "parquet-common" % parquetVersion,
-      "com.spotify" %% "magnolify-parquet" % magnolifyVersion,
-      // #3260 work around for sorter memory limit until we patch upstream
-      // "org.apache.beam" % "beam-sdks-java-extensions-sorter" % beamVersion,
       "org.apache.beam" % "beam-sdks-java-extensions-protobuf" % beamVersion,
       "com.google.apis" % "google-api-services-bigquery" % googleApiServicesBigQuery,
       "org.tensorflow" % "tensorflow-core-platform" % tensorFlowVersion,
@@ -1113,7 +1164,6 @@ lazy val `scio-smb`: Project = project
       "org.hamcrest" % "hamcrest-library" % hamcrestVersion % Test,
       "com.novocode" % "junit-interface" % junitInterfaceVersion % Test,
       "junit" % "junit" % junitVersion % Test,
-      "com.chuusai" %% "shapeless" % shapelessVersion,
       "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
       "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
@@ -1122,7 +1172,15 @@ lazy val `scio-smb`: Project = project
       "org.apache.beam" % "beam-vendor-guava-26_0-jre" % beamVendorVersion,
       "org.slf4j" % "slf4j-api" % slf4jVersion,
       "com.github.ben-manes.caffeine" % "caffeine" % caffeineVersion % "provided"
-    ).map(_.withDottyCompat(scalaVersion.value)),
+    ),
+    // Scala dependencies not ported to Scala 3 yet
+    libraryDependencies ++= Seq(
+      //"org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+      "com.spotify" %% "magnolify-parquet" % magnolifyVersion,
+      // #3260 work around for sorter memory limit until we patch upstream
+      // "org.apache.beam" % "beam-sdks-java-extensions-sorter" % beamVersion,
+      "com.chuusai" %% "shapeless" % shapelessVersion,
+   ).map(_.cross(CrossVersion.for3Use2_13)),
     javacOptions ++= {
       (Compile / sourceManaged).value.mkdirs()
       Seq("-s", (Compile / sourceManaged).value.getAbsolutePath)
@@ -1146,14 +1204,18 @@ lazy val `scio-redis`: Project = project
   .settings(itSettings)
   .settings(
     description := "Scio integration with Redis",
+    // Java dependencies
     libraryDependencies ++= Seq(
-      "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
       "com.google.protobuf" % "protobuf-java" % protobufVersion,
       "com.google.guava" % "guava" % guavaVersion,
       "org.apache.beam" % "beam-sdks-java-core" % beamVersion,
-      "org.scalatest" %% "scalatest" % scalatestVersion % Test,
       "org.apache.beam" % "beam-sdks-java-io-redis" % beamVersion
-    ).map(_.withDottyCompat(scalaVersion.value))
+    ),
+    // Scala dependencies not ported to Scala 3 yet
+    libraryDependencies ++= Seq(
+      //"org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
+     "org.scalatest" %% "scalatest" % scalatestVersion % Test,
+    ).map(_.cross(CrossVersion.for3Use2_13))
   )
   .dependsOn(
     `scio-core`,
@@ -1282,9 +1344,9 @@ lazy val soccoSettings = if (sys.env.contains("SOCCO")) {
     addCompilerPlugin(("io.regadas" %% "socco-ng" % "0.1.4").cross(CrossVersion.full)),
     // Generate scio-examples/target/site/index.html
     soccoIndex := SoccoIndex.generate(target.value / "site" / "index.html"),
-    compile in Compile := {
+    Compile / compile := {
       val _ = soccoIndex.value
-      (compile in Compile).value
+      (Compile / compile).value
     }
   )
 } else {
@@ -1294,13 +1356,14 @@ lazy val soccoSettings = if (sys.env.contains("SOCCO")) {
 //strict should only be enabled when updating/adding depedencies
 // ThisBuild / conflictManager := ConflictManager.strict
 //To update this list we need to check against the dependencies being evicted
+
+// Java overrides
 ThisBuild / dependencyOverrides ++= Seq(
   "org.threeten" % "threetenbp" % "1.4.1",
   "org.conscrypt" % "conscrypt-openjdk-uber" % "2.2.1",
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
   "com.google.api-client" % "google-api-client" % googleClientsVersion,
   "com.google.api.grpc" % "proto-google-cloud-datastore-v1" % generatedDatastoreProtoVersion,
   "com.google.api.grpc" % "proto-google-common-protos" % "1.17.0",
@@ -1326,7 +1389,6 @@ ThisBuild / dependencyOverrides ++= Seq(
   "com.google.oauth-client" % "google-oauth-client" % googleOauthClientVersion,
   "com.google.protobuf" % "protobuf-java-util" % protobufVersion,
   "com.google.protobuf" % "protobuf-java" % protobufVersion,
-  "com.propensive" %% "magnolia" % magnoliaVersion,
   "com.squareup.okio" % "okio" % "1.13.0",
   "com.thoughtworks.paranamer" % "paranamer" % "2.8",
   "commons-cli" % "commons-cli" % "1.2",
@@ -1335,9 +1397,6 @@ ThisBuild / dependencyOverrides ++= Seq(
   "commons-io" % "commons-io" % commonsIoVersion,
   "commons-lang" % "commons-lang" % "2.6",
   "commons-logging" % "commons-logging" % "1.2",
-  "io.circe" %% "circe-core" % circeVersion,
-  "io.circe" %% "circe-generic" % circeVersion,
-  "io.circe" %% "circe-parser" % circeVersion,
   "io.dropwizard.metrics" % "metrics-core" % "3.2.2",
   "io.grpc" % "grpc-auth" % grpcVersion,
   "io.grpc" % "grpc-context" % grpcVersion,
@@ -1386,17 +1445,28 @@ ThisBuild / dependencyOverrides ++= Seq(
   "org.hamcrest" % "hamcrest-core" % hamcrestVersion,
   "org.objenesis" % "objenesis" % "2.5.1",
   "org.ow2.asm" % "asm" % "5.0.4",
-  "org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion,
-  "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
-  "org.scalacheck" %% "scalacheck" % scalacheckVersion,
-  "org.scalactic" %% "scalactic" % scalatestVersion,
-  "org.scalatest" %% "scalatest" % scalatestVersion,
   "org.slf4j" % "slf4j-api" % slf4jVersion,
   "org.slf4j" % "slf4j-log4j12" % slf4jVersion,
   "org.tukaani" % "xz" % "1.8",
-  "org.typelevel" %% "algebra" % algebraVersion,
-  "org.typelevel" %% "cats-core" % catsVersion,
   "org.xerial.snappy" % "snappy-java" % "1.1.4",
   "org.yaml" % "snakeyaml" % "1.12",
-  "com.nrinaudo" %% "kantan.codecs" % kantanCodecsVersion
+)
+
+ThisBuild / dependencyOverrides ++= Seq(
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
+  "com.propensive" %% "magnolia" % magnoliaVersion,
+  "io.circe" %% "circe-core" % circeVersion,
+  "io.circe" %% "circe-generic" % circeVersion,
+  "io.circe" %% "circe-parser" % circeVersion,
+  "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
+  "com.nrinaudo" %% "kantan.codecs" % kantanCodecsVersion,
+  //"org.scala-lang.modules" %% "scala-collection-compat" % scalaCollectionCompatVersion
+).map(_.cross(CrossVersion.for3Use2_13))
+
+ThisBuild / dependencyOverrides ++= Seq(
+  "org.typelevel" %% "algebra" % algebraVersion,
+  "org.typelevel" %% "cats-core" % catsVersion,
+  "org.scalacheck" %% "scalacheck" % scalacheckVersion,
+  "org.scalactic" %% "scalactic" % scalatestVersion,
+  "org.scalatest" %% "scalatest" % scalatestVersion
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.5.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,6 @@ addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.3")
 
 libraryDependencies ++= Seq(
   "com.github.os72" % "protoc-jar" % "3.11.4",

--- a/scio-core/src/main/scala/com/spotify/scio/schemas/SchemaMaterializer.scala
+++ b/scio-core/src/main/scala/com/spotify/scio/schemas/SchemaMaterializer.scala
@@ -150,7 +150,7 @@ object SchemaMaterializer {
     schema
       .toList(v)
       .asScala
-      .map[schema.schema.Repr](dispatchEncode(schema.schema, fieldType.getCollectionElementType))
+      .map(dispatchEncode(schema.schema, fieldType.getCollectionElementType): A => schema.schema.Repr)
       .asJava
 
   private def encode[F[_, _], A, B](schema: MapType[F, A, B], fieldType: BFieldType)(

--- a/scio-macros/src/main/scala-3/com/spotify/scio/DerivationUtils.scala
+++ b/scio-macros/src/main/scala-3/com/spotify/scio/DerivationUtils.scala
@@ -27,12 +27,12 @@ object DerivationUtils {
       case _ => Nil
     }
 
-  inline given summonAllF[F[_], T <: Tuple]: Widen[T] = {
+  inline given summonAllF[F[_], T <: Tuple]: T = {
     val res =
       inline erasedValue[T] match {
         case _: EmptyTuple => EmptyTuple
         case _: (t *: ts) => summonInline[F[t]] *: summonAllF[F, ts]
       }
-    res.asInstanceOf[Widen[T]]
+    res.asInstanceOf[T]
   }
 }


### PR DESCRIPTION
This PR removes `sbt-dotty` and upgrades to sbt 1.5.0 and Scala 3.0.0-RC2.

The biggest difficulty involves library dependencies.
`withDottyCompat` which is now `.cross` should not be used on Java dependencies and on all Scala dependencies.
I separated the `libraryDependencies` which contained only Java dependencies from others. Then I also separated the Scala dependencies which require cross versions from those that do not.
Many modules still have some conflict issues, but I propose that we fix them iteratively as we work on them as it is a very tedious process to remove ported/non-ported and incompatible bits.

As libraries progressively are ported to Scala 3, the list of cross-versioned dependencies should shrink.